### PR TITLE
fix(sec): upgrade @finastra/nestjs-proxy to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@chainsafe/libp2p-noise": "5.0.0",
     "@aws-crypto/decrypt-node": "2.0.0",
     "@aws-crypto/decrypt-browser": "2.0.0",
-    "@finastra/nestjs-proxy": "0.4.0"
+    "@finastra/nestjs-proxy": "0.7.0"
   },
   "eslintConfig": {
     "root": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,12 +1477,13 @@
     fastify-plugin "^3.0.0"
     ws "^8.0.0"
 
-"@finastra/nestjs-proxy@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.npmmirror.com/@finastra/nestjs-proxy/-/nestjs-proxy-0.4.0.tgz#122f801036e3d62f5b13d2b953aad1fffab7f40d"
-  integrity sha512-Xyv6oalyVdmWgXfAnMBPl2LzOSdwy5PpB7oYV6Wtq4+79M+wh74JiRNMPVyKxsbkmmxT+09DsBtt1ogkynppJw==
+"@finastra/nestjs-proxy@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.npmmirror.com/@finastra/nestjs-proxy/-/nestjs-proxy-0.7.0.tgz#5bb9ea6b468ba5af09f8a63d1bb129526ec96f21"
+  integrity sha512-FaBv4Lk663/Eqij3lPwSRYEsjtwKgb6oq+6JGPp7y9thKVWAtrVF5NRcpn9i0uG2QnaXwXJYitx0kwhE6i/u/w==
   dependencies:
-    http-proxy "^1.18.0"
+    http-proxy "^1.18.1"
+    url-join "^4.0.1"
 
 "@graphql-tools/merge@8.3.1":
   version "8.3.1"
@@ -10348,7 +10349,7 @@ http-proxy-middleware@^2.0.3:
     is-plain-obj "^3.0.0"
     micromatch "^4.0.2"
 
-http-proxy@^1.13.0, http-proxy@^1.18.0, http-proxy@^1.18.1:
+http-proxy@^1.13.0, http-proxy@^1.18.1:
   version "1.18.1"
   resolved "https://registry.npmmirror.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
   integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
@@ -18845,6 +18846,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmmirror.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==
+
+url-join@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmmirror.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
+  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
 
 url-parse-lax@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in @finastra/nestjs-proxy 0.4.0
- [CVE-2022-31069](https://www.oscs1024.com/hd/CVE-2022-31069)


### What did I do？
Upgrade @finastra/nestjs-proxy from 0.4.0 to 0.7.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS